### PR TITLE
Fix readline with non-system pythons on OSX

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -149,7 +149,7 @@ def prompt_for_value(prompt, values, default):
     # name and don't indicate a new word
     readline.set_completer_delims("")
     readline.set_completer(completer)
-    if(sys.platform == 'darwin'):
+    if 'libedit' in readline.__doc__:
         readline.parse_and_bind ("bind ^I rl_complete")
     else:
         readline.parse_and_bind("tab: complete")


### PR DESCRIPTION
Non-Apple pythons (say if you install from source or use the official python.org installer) don't have the libedit problem mentioned [here](http://docs.python.org/release/2.7.3/library/readline.html), but they do have `sys.platform == 'darwin'`, which causes icsv2ledger's tab completion not to work.  This patch fixes the problem by checking for the actual presence of libedit, rather than just the darwin platform.
