### PR TITLE
Nicer error message when mapping files contain invalid regexes

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -129,7 +129,12 @@ def read_mappings(map_file):
             if len(row) > 1:
                 pattern, account = row[0].strip(), row[1].strip()
                 if pattern.startswith('/') and pattern.endswith('/'):
-                    pattern = re.compile(pattern[1:-1])
+                    try:
+                        pattern = re.compile(pattern[1:-1])
+                    except re.error as e:
+                        sys.stderr.write("Invalid regex '%s' in '%s': %s\n" %
+                                         (pattern, map_file, e))
+                        sys.exit(1)
                 mappings.append((pattern, account))
     return mappings
 


### PR DESCRIPTION
If I have a mapping file entry that contains an invalid regex such as:

```
"/*.BLACK CAB VIC.*/","Expenses:Transport:Taxi"
```

(note the transposition of '.' and '*'), icsv2ledger currently prints a stack trace that isn't very helpful in tracking down the error.  This patch adds reporting around the filename and exact regex that caused the error.
