### PR TITLE
Replace no_header with skip_lines option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ credit=2
 debit=-1
 accounts_map=mappings.SAV
 payees_map=payees.SAV
-no_header=True
 
 [CHQ]
 account=Assets:Bank:Cheque Account
@@ -44,7 +43,7 @@ credit=3
 debit=4
 accounts_map=mappings.CHQ
 payees_map=payees.CHQ
-no_header=False
+skip_lines=0
 </pre>
 
 The configuration file contains one section per bank account you wish to import.
@@ -70,7 +69,8 @@ Now for each account you need to specify the following:
   column, than just set `debit` to be "-1" and icsv2ledger will do the right thing. _Mandatory_
 * `accounts_map` is the file which holds the mapping between the description and the account name to use. _Mandatory_
 * `payees_map` is the file which holds the mapping between the description and the payee to use. _Mandatory_
-* `no_header` should be set to true if first row in the CSV file is not a header. Default is 'False'. _Optional_
+* `skip_lines` is the number of lines to skip from the beginning of the CSV
+  file. The default is `1` to skip the CSV header line. _Optional_
 * `cleared_character` is character to mark a transaction as cleared.
   Ledger possible value are `*` or `!` or ` `. Default is `*`. _Optional_
 

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -206,7 +206,7 @@ def main():
         defaults={
             'default_expense': 'Expenses:Unknown',
             'append_currency': False,
-            'no_header': False,
+            'skip_lines': '1',
             'cleared_character': '*'})
 
     if os.path.exists(options.config):
@@ -226,7 +226,7 @@ def main():
 
     options.accounts_map_file = config.get(options.account, 'accounts_map')
     options.payees_map_file = config.get(options.account, 'payees_map')
-    options.no_header = config.getboolean(options.account, 'no_header')
+    options.skip_lines = config.getint(options.account, 'skip_lines')
 
     # We prime the list of accounts and payees by running Ledger on the specified file
     accounts = set([])
@@ -303,7 +303,7 @@ def main():
 
             bank_reader = csv.reader(bank_file)
             # We hardcode the fields, so want to ignore the first line if it's just field names
-            if not options.no_header: bank_reader.next()
+            for x in range(0, options.skip_lines): bank_reader.next()
 
             # If output file not specified, use input filename with '.ledger' extension
             if not output_file:


### PR DESCRIPTION
Some banks export their CSV with several lines of text as a header,
containing the account number, type of account, the current balance,
or other information such as the CSV row header.

With the skip_lines option icsv2ledger skips these lines prior to
reading the actual CSV data.

Sample CSV export from bank statement including CSV row header:
"Account:","1234567890 / Internet-Account",

"From:","01.01.2012",
"To:","01.02.2012",
"Balance:","123,45",

"Date","Effective Date","Transactiontext","Payee","Purpose","Account","BIN","Amount",
