### PR TITLE
Replace date_format with csv_date_format and ledger_date_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The following is an example configuration file.
 account=Assets:Bank:Savings Account
 currency=AUD
 date=1
-date_format=%d-%b-%y
+csv_date_format=%d-%b-%y
+ledger_date_format=%Y/%m/%d
 desc=6
 credit=2
 debit=-1
@@ -38,7 +39,8 @@ no_header=True
 account=Assets:Bank:Cheque Account
 currency=AUD
 date=1
-date_format=%d/%m/%Y
+csv_date_format=%d/%m/%Y
+ledger_date_format=%Y/%m/%d
 desc=2
 credit=3
 debit=4
@@ -60,8 +62,11 @@ Now for each account you need to specify the following:
   is "False", so prepend, that is before amount. _Optional_
 * `date` is the column in the CSV file which records the transaction date.
   The first column in the CSV file is numbered 1. _Mandatory_
-* `date_format` describes the format of the date.
-  See the [python documentation](http://docs.python.org/library/datetime.html#strftime-strptime-behavior) for the various format codes supported in this expression. _Mandatory_
+* `csv_date_format` describes the format of the date in the CSV file.
+  See the [python documentation](http://docs.python.org/library/datetime.html#strftime-strptime-behavior) for the various format codes supported in this expression. _Optional_
+* `ledger_date_format` describes the format to be used when creating ledger
+  entries.  By default the same date format from the CSV file is used.
+  See the [python documentation](http://docs.python.org/library/datetime.html#strftime-strptime-behavior) for the various format codes supported in this expression. _Optional_
 * `desc` is the column containing the transaction description as supplied by the bank.
   This is the column that will be used as the input for determing which payee and account to use by the auto-completion. _Mandatory_
 * `credit` is the column which contains credits to the account. _Mandatory_

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -40,7 +40,16 @@ class Entry:
 
         # Get the date and convert it into a ledger formatted date.
         self.date = row[config.getint(csv_account, 'date') - 1]
-        self.date = datetime.strptime(self.date, config.get(csv_account, 'date_format')).strftime("%Y/%m/%d")
+        if config.has_option(csv_account, 'csv_date_format'):
+            csv_date_format = config.get(csv_account, 'csv_date_format')
+        else:
+            csv_date_format = ""
+        if config.has_option(csv_account, 'ledger_date_format'):
+            ledger_date_format = config.get(csv_account, 'ledger_date_format')
+        else:
+            ledger_date_format = ""
+        if ledger_date_format != csv_date_format:
+            self.date = datetime.strptime(self.date, csv_date_format).strftime(ledger_date_format)
 
         self.desc = row[config.getint(csv_account, 'desc') - 1]
         self.desc.strip()
@@ -219,7 +228,7 @@ def main():
         print "Config file " + options.config + " does not contain section " + options.account
         return
 
-    for o in ['account', 'date', 'date_format', 'desc', 'credit', 'debit', 'accounts_map', 'payees_map']:
+    for o in ['account', 'date', 'desc', 'credit', 'debit', 'accounts_map', 'payees_map']:
         if not config.has_option(options.account, o):
             print "Config file " + options.config + " section " + options.account + " does not contain option " + o
             return


### PR DESCRIPTION
By default the same date format from the CSV is be used.

If the user would like the ledger file to use a different format,
the date is parsed from the CSV using csv_date_format and printed
to the ledger file using ledger_date_format.
