### PR TITLE
ledger file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Now for each account you need to specify the following:
   file. The default is `1` to skip the CSV header line. _Optional_
 * `cleared_character` is character to mark a transaction as cleared.
   Ledger possible value are `*` or `!` or ` `. Default is `*`. _Optional_
+* `ledger_file` is ledger file where to get the list of already defined
+  accounts and payees. _Optional_
 
 To run, use the following command
 

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -198,8 +198,8 @@ def main():
     parser.add_option("-o", "--output-file", dest="output_file",
                       help="Ledger file for output (default file1.ledger etc)",
                       default=None)
-    parser.add_option("-r", "--read-file", dest="ledger_file",
-                      help="Read accounts from ledger file")
+    parser.add_option("-l", "--ledger-file", dest="ledger_file",
+                      help="Read payees/accounts from ledger file")
     parser.add_option("-q", "--quiet", dest="quiet",
                       help="Don't prompt if account can be deduced, just use it",
                       default=False, action="store_true")
@@ -236,6 +236,7 @@ def main():
     options.accounts_map_file = config.get(options.account, 'accounts_map')
     options.payees_map_file = config.get(options.account, 'payees_map')
     options.skip_lines = config.getint(options.account, 'skip_lines')
+    options.ledger_file = config.get(options.account, 'ledger_file')
 
     # We prime the list of accounts and payees by running Ledger on the specified file
     accounts = set([])


### PR DESCRIPTION
Add ability to read ledger filename from configuration file.
Rename --read-file to --ledger-file. I propose this because there is some many files to read (input file, mapping file, ledger file) that confusion arise, and I prefer something more explicit
