### PR TITLE
Determine CSV dialect and preserve original CSV

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -72,9 +72,7 @@ class Entry:
         else:
             self.transaction_template = ""
 
-        # Ironically, we have to recreate the CSV line to keep it for reference
-        # I don't think the otherwise excellent CSV library has a way to get the original line.
-        self.csv = csv
+        self.csv = csv.strip()
 
         # We also record this - in future we may use it to avoid duplication
         self.md5sum = hashlib.md5(self.csv).hexdigest()


### PR DESCRIPTION
The CSV export for an account statement may have a different delimiter
than the default (','), icsv2ledger analyzes the CSV to determine the
specific dialect used for parsing.  This adds support for various CSV formats.

The value of the CSV tag is now the original CSV line as it was read,
this will help when verifying the generated ledger transaction with
the original CSV source using the MD5Sum tag.
