### PR TITLE
Improve handling of ledger_file option

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -247,7 +247,8 @@ def main():
     options.accounts_map_file = config.get(options.account, 'accounts_map')
     options.payees_map_file = config.get(options.account, 'payees_map')
     options.skip_lines = config.getint(options.account, 'skip_lines')
-    options.ledger_file = config.get(options.account, 'ledger_file')
+    if not options.ledger_file and config.has_option(options.account, 'ledger_file'):
+        options.ledger_file = config.get(options.account, 'ledger_file')
 
     # We prime the list of accounts and payees by running Ledger on the specified file
     accounts = set([])


### PR DESCRIPTION
The ledger_file option can be given on the command line or be configured
in .icsv2ledgerrc.  When the option is not configred in the .icsv2ledgerrc
file the icsv2ledger errs with:

```
Traceback (most recent call last):
  File "icsv2ledger/icsv2ledger.py", line 357, in <module>
    main()
  File "icsv2ledger/icsv2ledger.py", line 250, in main
    options.ledger_file = config.get(options.account, 'ledger_file')
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ConfigParser.py", line 610, in get
    raise NoOptionError(option, section)
ConfigParser.NoOptionError: No option 'ledger_file' in section: 'giro'
```

This change remedies the above error and prefers a given commandline option
over a configured option, when both are available.
