### PR TITLE
Use template to generate ledger transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage:
 
 Arguments:
 
-	input.csv             Filename or stdin. CSV format.
+    input.csv             Filename or stdin. CSV format.
     output.ledger         Filename or stdout. Ledger format.
 
 Options:
@@ -94,8 +94,6 @@ Now for each account you need to specify the following:
 * `default_expense` is the default ledger account for expense. Default
   is 'Expenses:Unknown'. _Optional_
 * `currency` is the the currency of amounts. Default is none. _Optional_
-* `append_currency` will append the currency after the amount. Default
-  is `False`, so prepend, that is before amount. _Optional_
 * `date` is the column in the CSV file which records the transaction date.
   The first column in the CSV file is numbered 1. _Mandatory_
 * `csv_date_format` describes the format of the date in the CSV file.
@@ -117,6 +115,18 @@ Now for each account you need to specify the following:
   Ledger possible value are `*` or `!` or ` `. Default is `*`. _Optional_
 * `ledger_file` is ledger file where to get the list of already defined
   accounts and payees. _Optional_
+* `transaction_template` path to a file containing the template to use when
+  generating ledger transactions. _Optional_<br>
+  Details on how to format the template are found in the [Format Specification Mini-Language](http://docs.python.org/library/string.html#formatspec).
+  The built-in default template is as follows:
+
+<pre>
+{date} {cleared_character} {payee}
+    ; MD5Sum: {md5sum}
+    ; CSV: {csv}
+    {debit_account:<60}    {debit_currency} {debit}
+    {credit_account:<60}    {credit_currency} {credit}
+</pre>
 
 
 Mapping file

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -66,21 +66,13 @@ class Entry:
 
         self.csv_account = config.get(csv_account, 'account')
         self.currency = config.get(csv_account, 'currency')
-        self.append_currency = config.getboolean(csv_account, 'append_currency')
         self.cleared_character = config.get(csv_account, 'cleared_character')
 
-        # Append the currency to the credits and debits.
-        if self.credit != "":
-            if self.append_currency:
-                self.credit = self.credit + " " + self.currency
-            else:
-                self.credit = self.currency + " " + self.credit
-
-        if self.debit != "":
-            if self.append_currency:
-                self.debit = self.debit + " " + self.currency
-            else:
-                self.debit = self.currency + " " + self.debit
+        if config.has_option(csv_account, 'transaction_template'):
+            with open (config.get(csv_account, 'transaction_template'), 'r') as template_file:
+                self.transaction_template = template_file.read().rstrip()
+        else:
+            self.transaction_template = ""
 
         # Ironically, we have to recreate the CSV line to keep it for reference
         # I don't think the otherwise excellent CSV library has a way to get the original line.
@@ -98,19 +90,35 @@ class Entry:
         """
         return "%s %-40s %s" % (self.date, self.desc, self.credit if self.credit else "-" + self.debit)
 
-    def journal_entry(self, account, payee, output_tags):
+    def journal_entry(self, account, payee):
         """
         Return a formatted journal entry recording this Entry against the specified Ledger account/
         """
-        out  = "%s %s %s\n" % (self.date, self.cleared_character, payee)
+        default_template = """\
+{date} {cleared_character} {payee}
+    ; MD5Sum: {md5sum}
+    ; CSV: {csv}
+    {debit_account:<60}    {debit_currency} {debit}
+    {credit_account:<60}    {credit_currency} {credit}
+        """
+        template = self.transaction_template if self.transaction_template else default_template
+        format_data = {
+                'date': self.date,
+                'cleared_character': self.cleared_character,
+                'payee': payee,
 
-        if output_tags:
-            out += "    ; MD5Sum: %s\n" % self.md5sum
-            out += "    ; CSV: \"%s\"\n" % self.csv
+                'debit_account': account,
+                'debit_currency': self.currency if self.debit else "",
+                'debit': self.debit,
 
-        out += "    %-60s%s\n" % (account, ("   " + self.debit) if self.debit else "")
-        out += "    %-60s%s\n" % (self.csv_account,  ("   " + self.credit) if self.credit else "")
-        return out
+                'credit_account': self.csv_account,
+                'credit_currency': self.currency if self.credit else "",
+                'credit': self.credit,
+
+                'md5sum': self.md5sum,
+                'csv': self.csv,
+        }
+        return template.format(**format_data)
 
 
 def payees_from_ledger(ledger_file):
@@ -203,9 +211,6 @@ def main():
     parser.add_option("-a", "--account", dest="account",
                       help="The Ledger account of this statement (Assets:Bank:Current)",
                       default="Assets:Bank:Current")
-    parser.add_option("--no-output-tags", dest="output_tags",
-                      help="Don't output the MD5SUM and CSV tags in the ledger transaction",
-                      default=True, action="store_false")
     (options, args) = parser.parse_args()
 
     # Because of python bug http://bugs.python.org/issue974019,
@@ -213,7 +218,6 @@ def main():
     config = ConfigParser.ConfigParser(
         defaults={
             'default_expense': 'Expenses:Unknown',
-            'append_currency': 'False',
             'skip_lines': '1',
             'cleared_character': '*'})
 
@@ -364,7 +368,7 @@ def main():
             entry = Entry(row, config, options.account)
             account = get_account(entry)
             payee = get_payee(entry)
-            ledger_lines.append(entry.journal_entry(account, payee, options.output_tags))
+            ledger_lines.append(entry.journal_entry(account, payee))
 
         return ledger_lines
 


### PR DESCRIPTION
Some people prefer tabs over whitespace or 2 spaces over 4 or 8 spaces
for indentation. Additionally some people prefer their ledger tags to
be indented further from the postings. And others like the order of the
postings in a transaction reversed.

Using a transaction template file, where placeholders are replaced with
the actual values from a transaction, the user can configure the
generated ledger output to their heart's content.

These changes make the `--no-output-tags` and the `append_currency` option
obsolete, since the template provides same functionality with much more
flexibility.
