### PR TITLE
Add _addon section for accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ The following is an example configuration file.
     credit=2
     debit=-1
     mapping_file=mappings.SAV
+    
+    [SAV_addon]
+    beneficiary=3
+    purpose=4
+    
      
     [CHQ]
     account=Assets:Bank:Cheque Account
@@ -87,6 +92,14 @@ The following is an example configuration file.
 
 The configuration file contains one section per bank account you wish to import.
 In the above example there are two bank accounts: SAV and CHQ.
+
+The `SAV_addon` section passes the addtional data from the configured CSV fields
+to the ledger transaction template for the SAV account. Given the above
+configuration your own transaction template could include the additional
+data as tags using:
+
+     ; purpose: {addon_purpose}
+     ; beneficiary: {addon_beneficiary}
 
 Now for each account you need to specify the following:
 

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -37,6 +37,13 @@ class Entry:
 
         """
 
+
+        self.addons = {}
+        if config.has_section(csv_account + "_addons"):
+            for item in config.items(csv_account + "_addons"):
+                if item in config.defaults().items(): continue
+                self.addons['addon_'+item[0]] = row[int(item[1])-1]
+
         # Get the date and convert it into a ledger formatted date.
         self.date = row[config.getint(csv_account, 'date') - 1]
         if config.has_option(csv_account, 'csv_date_format'):
@@ -121,7 +128,7 @@ class Entry:
 
             'md5sum': self.md5sum,
             'csv': self.csv}
-        return template.format(**format_data)
+        return template.format(**dict(format_data.items() + self.addons.items()))
 
 
 def payees_from_ledger(ledger_file):


### PR DESCRIPTION
Allow additional information such as purpose, benificary,
or type of transation from the CSV bank statement to be stored
as additional ledger tags.

I'm not completely happy with how this works and kindly
ask for your opinion.
