### PR TITLE
Concatenate desc from multiple csv fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Now for each account you need to specify the following:
   entries.  By default the same date format from the CSV file is used.
   See the [python documentation](http://docs.python.org/library/datetime.html#strftime-strptime-behavior) for the various format codes supported in this expression. _Optional_
 * `desc` is the column containing the transaction description as supplied by the bank.
-  This is the column that will be used as the input for determing which payee and account to use by the auto-completion. _Mandatory_
+  This is the column that will be used as the input for determing which payee and account to use by the auto-completion.
+  It is possible to provide a comma separated list of csv column indices that should be concatenated to in order to form a unique description.  _Mandatory_
 * `credit` is the column which contains credits to the account. _Mandatory_
 * `debit` is the column which contains debits to the account.
   If your bank represents debits as negative numbers in the credit

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -59,7 +59,10 @@ class Entry:
                          .strptime(self.date, csv_date_format)
                          .strftime(ledger_date_format))
 
-        self.desc = row[config.getint(csv_account, 'desc') - 1].strip()
+        desc = []
+        for index in re.compile(',\s*').split(config.get(csv_account, 'desc')):
+            desc.append(row[int(index) - 1].strip())
+        self.desc = ' '.join(desc).strip()
 
         if config.getint(csv_account, 'credit') < 0:
             self.credit = ""


### PR DESCRIPTION
Some banks issue an account statement that has a payee and a purpose
field (see example translated from German below), which make a more
precise desc for transaction mapping.

These changes allow the desc configuration in the `~/.icsv2legerrc` to
be a comma separated list of csv column indices which will be
concatenated to form a more precise and unique desc used for mapping.

Example bank statement CSV header with two fields relevant for desc.
`"Date","Effective Date","Transactiontext","Payee","Purpose","Account","BIN","Amount",`
