### PR TITLE
Allow entry of ledger dates in tags

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -196,7 +196,7 @@ def append_mapping_file(map_file, desc, payee, account, tags):
 
 
 def tagify(value):
-    if value.find(':') < 0 :
+    if value.find(':') < 0 and value[0] != '[' and value[-1] != ']':
       value = ":{0}:".format(value)
     return value
 


### PR DESCRIPTION
Some transaction postings can have a different date, than
the transaction (e.g. effective date). These dates can be
added as tags in ledger and icsv2ledger should handle entry
of dates as tags accordingly (e.g. [=2012/10/24]).
