### PR TITLE
Add ability to negate amount. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The file used will be first found in that order:
 is the CSV file column which contains _credit_ amounts. The first column
 in the CSV file is numbered 1. Default is `4`.
 
+See also documentation of `--debit` option for negating amounts.
+
 **`--csv-date-format STR`**
 
 describes the date format in the CSV file. See the
@@ -155,9 +157,12 @@ is the CSV file column which contains the transaction date. Default is
 
 is the CSV file column which contains _debit_ amounts. Default is `3`.
 
-If your bank represents debits as negative numbers in the credit column,
-than just set `debit` to be `-1` and icsv2ledger will do the right
-thing.
+If your bank write all amounts in same column, credits as positive
+amounts and debits as negative amounts, then set `debit` to `0`.
+
+If your bank write debits as negative number and you want to negate the
+amount, then use `--debit=-3`. It will negate amounts in column 3 and
+use them as debits amounts.
 
 **`--default-expense STR`**
 

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -302,14 +302,18 @@ class Entry:
         self.desc = ' '.join(desc).strip()
 
         if options.credit < 0:
-            self.credit = ""
-        else:
+            self.credit = -row[options.credit - 1]
+        elif options.credit > 0:
             self.credit = row[options.credit - 1]
+        else:
+            self.credit = ''
 
         if options.debit < 0:
-            self.debit = ""
-        else:
+            self.debit = -row[options.debit - 1]
+        elif options.debit > 0:
             self.debit = row[options.debit - 1]
+        else:
+            self.debit = ''
 
         self.csv_account = options.account
         self.currency = options.currency


### PR DESCRIPTION
This commit keep existing functionality (but somewhat break it) of having credit and debit in same column, but '0'  must now be used as debit column for that. The '-3' notation is now used to negate amounts in column 3.
