### PR TITLE
Fix tags IndexError

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -550,7 +550,7 @@ def main():
 
         if not found or (found and modified):
             # Add new or changed mapping to mappings and append to file
-            mappings.append((entry.desc, payee, account))
+            mappings.append((entry.desc, payee, account, tags))
             append_mapping_file(options.mapping_file,
                                 entry.desc, payee, account, tags)
 


### PR DESCRIPTION
Without this fix, the auto completion exits (see message below) because m[3] is not defined. This because it was not saved.

Traceback (most recent call last):
  File "/home/thierry/dev/icsv2ledger/icsv2ledger.py", line 608, in <module>
    main()
  File "/home/thierry/dev/icsv2ledger/icsv2ledger.py", line 605, in main
    process_input_output(options.infile, options.outfile)
  File "/home/thierry/dev/icsv2ledger/icsv2ledger.py", line 587, in process_input_output
    ledger_lines = process_csv_lines(csv_lines)
  File "/home/thierry/dev/icsv2ledger/icsv2ledger.py", line 599, in process_csv_lines
    payee, account, tags = get_payee_and_account(entry)
  File "/home/thierry/dev/icsv2ledger/icsv2ledger.py", line 523, in get_payee_and_account
    payee, account, tags = m[1], m[2], m[3]
IndexError: tuple index out of range
