### PR TITLE
Md5check

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -554,6 +554,7 @@ def main():
     possible_accounts = set([])
     possible_payees = set([])
     possible_tags = set([])
+    md5entries = set([])
     if options.ledger_file:
         possible_accounts = accounts_from_ledger(options.ledger_file)
         possible_payees = payees_from_ledger(options.ledger_file)


### PR DESCRIPTION
Hacked in quick support to check if a CSV entry has already been imported.  It's a little kludgy but it seems to work.

It scans the ledger file specified by the `-l` option by calling `ledger print` and then looking at the output for lines with 'MD5Sum' in them.  Once it finds those lines, match a regex against an md5sum and stick it all in a list.

As entries are scanned and processed, if the entry's md5sum is in the list generated above, ask the user if they'd like to skip it.

I'm sure you might want to polish some of this up, but it seems to be working.