### PR TITLE
Add option for --effective-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Options can either be used from command line or in configuration file.
                           ledger account used as destination
     --delimiter           CSV delimiter
     --desc STR            CSV column number matching description
+    --effective-date INT  CSV column number matching effective date
     --ledger-date-format STR
                           date format for ledger output file
     --ledger-file FILE, -l FILE
@@ -189,6 +190,13 @@ It is possible to provide a comma separated list of CSV column indices
 (like `desc=2,5`) that will concatenate fields in order to form a unique
 description. That enriched description will serve as base for the
 mapping.
+
+**`--effective-date INT`**
+
+is the CSV column number which contains the date to be used as the
+effective date. Default is `0`. Use of this option currently requires a
+template file. See section
+[Transaction template file](#transaction-template-file).
 
 **`--ledger-date-format STR`**
 
@@ -358,8 +366,8 @@ The built-in default template is as follows:
 Details on how to format the template are found in the
 [Format Specification Mini-Language](http://docs.python.org/library/string.html#formatspec).
 
-The value that can be used are: `date`, `cleared_character`, `payee`,
-`transaction_index`, `debit_account`, `debit_currency`, `debit`,
+The values that can be used are: `date`, `effective_date`, `cleared_character`,
+`payee`, `transaction_index`, `debit_account`, `debit_currency`, `debit`,
 `credit_account`, `credit_currency`, `credit`, `tags`, `md5sum`, `csv`.
 And also the addon tags like `addon_xxxx`. See section
 [Addons](#addons).

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -59,6 +59,7 @@ DEFAULTS = dotdict({
     'csv_date_format': '',
     'currency': get_locale_currency_symbol(),
     'date': str(1),
+    'effective_date': str(0),
     'debit': str(3),
     'default_expense': 'Expenses:Unknown',
     'desc': str(2),
@@ -221,6 +222,12 @@ def parse_args_and_config_file():
         help=('CSV column number matching date'
               ' (default: {0})'.format(DEFAULTS.date)))
     parser.add_argument(
+        '--effective-date',
+        metavar='INT',
+        type=int,
+        help=('CSV column number matching effective date'
+              ' (default: {0})'.format(DEFAULTS.effective_date)))
+    parser.add_argument(
         '--desc',
         metavar='STR',
         help=('CSV column number matching description'
@@ -323,6 +330,17 @@ class Entry:
                 self.date = (datetime
                              .strptime(self.date, options.csv_date_format)
                              .strftime(options.ledger_date_format))
+        # convert effective dates
+        if options.effective_date:
+            self.effective_date = fields[options.effective_date - 1]
+            if options.ledger_date_format:
+                if options.ledger_date_format != options.csv_date_format:
+                    self.effective_date = (datetime
+                                 .strptime(self.effective_date, options.csv_date_format)
+                                 .strftime(options.ledger_date_format))
+        else:
+            self.effective_date = ""
+
 
         desc = []
         for index in re.compile(',\s*').split(options.desc):
@@ -366,6 +384,7 @@ class Entry:
                     if self.transaction_template else DEFAULT_TEMPLATE)
         format_data = {
             'date': self.date,
+            'effective_date': self.effective_date,
             'cleared_character': self.cleared_character,
             'payee': payee,
             'transaction_index': transaction_index,


### PR DESCRIPTION
This patch allows for the specification of CSV column that contains a secondary date column such as a 'Posted Date'.  Use of this option requires a custom template file.

I have hopefully updated all the right bits of the script as well as the help file.

The formatting of the effective date assumes both that the CSV only contains one date format AND that both the transaction date and effective date should be in the same ledger format.  This conversion could probably be coded more cleanly, I'm open to suggestions.
