### PR TITLE
Prevent crash when realine.__doc__ is None.

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -545,7 +545,7 @@ def prompt_for_value(prompt, values, default):
     # name and don't indicate a new word
     readline.set_completer_delims("")
     readline.set_completer(completer)
-    if 'libedit' in readline.__doc__:
+    if readline.__doc__ and 'libedit' in readline.__doc__:
         readline.parse_and_bind("bind ^I rl_complete")
     else:
         readline.parse_and_bind("tab: complete")


### PR DESCRIPTION
When running on windows the pyreadline package can provide readline emulation. It does not provide a docstring though so the program will crash when checking for 'libedit' in the non existant readline.**doc** string.
