### PR TITLE
Support for more number formats by removing non-number characters

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -434,6 +434,13 @@ def get_field_at_index(fields, index, csv_decimal_comma, ledger_decimal_comma):
     else:
         value = fields[index - 1]
 
+    if csv_decimal_comma:
+        decimal_separator = ','
+    else:
+        decimal_separator = '.'
+    re_non_number = '[^-0-9' + decimal_separator + ']'
+    value = re.sub(re_non_number, '', value)
+
     if csv_decimal_comma and not ledger_decimal_comma:
         value = value.replace(',', '.')
     if not csv_decimal_comma and ledger_decimal_comma:


### PR DESCRIPTION
The CSV files from my (German) bank contain commas as decimal separator, dots "." as thousands separator and plus signs "+" for positive amounts. E.g.:

```
+160,00
-1.000,00
```

The plus signs and the thousands separators are not handled by ledger and should be removed from the output.

Instead of trying to support more number formats, I propose to simply strip off any offending characters which are not digits 0-9, minus "-" or the decimal separator "." or ",".
