### PR TITLE
CSV reading: continue without explicit dialect upon guess failure

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -662,8 +662,13 @@ def main():
         print(*ledger_lines, sep='\n', file=out_file)
 
     def process_csv_lines(csv_lines):
-        dialect = csv.Sniffer().sniff(
-            "\n".join(csv_lines[options.skip_lines:options.skip_lines + 3]), options.delimiter)
+        dialect = None
+        try:
+            dialect = csv.Sniffer().sniff(
+                "\n".join(csv_lines[options.skip_lines:options.skip_lines + 3]), options.delimiter)
+        except csv.Error:  # can't guess specific dialect, try without one
+            pass
+
         bank_reader = csv.reader(csv_lines[options.skip_lines:], dialect)
 
         ledger_lines = []


### PR DESCRIPTION
Rationale: the default settings of Python's csv module allow to read several
CSV sub-formats without having to specify a dialect. With this change we allow
to read them even when the CSV sniffer is unable to determine the actual
dialect in use.
