### PR TITLE
Add non-interactive mode

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -65,6 +65,7 @@ DEFAULTS = dotdict({
     'desc': str(2),
     'ledger_date_format': '',
     'quiet': False,
+    'interactive': True,
     'skip_lines': str(1),
     'tags': False,
     'delimiter': ',',
@@ -109,6 +110,11 @@ def find_first_file(arg_file, alternatives):
             break
     return found
 
+
+class MatchingFailed(Exception):
+    def __init__(self, line):
+        super(MatchingFailed, self).__init__()
+        self.line = line
 
 class SortingHelpFormatter(HelpFormatter):
     """Sort options alphabetically when -h prints usage
@@ -204,6 +210,20 @@ def parse_args_and_config_file():
         action='store_true',
         help=('do not prompt if account can be deduced'
               ' (default: {0})'.format(DEFAULTS.quiet)))
+    parser.add_argument(
+        '--noninteractive',
+        action='store_false', dest='interactive',
+        help=('do not prompt, print unprocessed lines to rejects-file'
+              ' and exit non-zero if any were encountered'
+              ' (default mode: {0})'.format('interactive')))
+    parser.add_argument(
+        '--rejects-file',
+        metavar='FILE',
+        type=argparse.FileType('w'),
+        default=sys.stderr,
+        help=('output rejects to filename or stderr in CSV syntax,'
+              ' only used when not interactive'
+              ' (default: {0})'.format('stderr')))
     parser.add_argument(
         '--default-expense',
         metavar='STR',
@@ -324,6 +344,8 @@ def parse_args_and_config_file():
               ' if ledger_date_format is defined.',
               file=sys.stderr)
         sys.exit(1)
+    if not args.interactive:
+        args.quiet = True
 
     return args
 
@@ -655,6 +677,8 @@ def main():
         modified = False
         if options.quiet and found:
             pass
+        elif not options.interactive:
+            raise MatchingFailed(entry.raw_csv)
         else:
             if options.clear_screen:
                 print('\033[2J\033[;H')
@@ -685,16 +709,19 @@ def main():
 
         return (payee, account, tags)
 
-    def process_input_output(in_file, out_file):
+    def process_input_output(in_file, out_file, err_file):
         """ Read CSV lines either from filename or stdin.
-        Process them.
+        Process them, if matching fails, write line to err_file or stderr.
         Write Ledger lines either to filename or stdout.
         """
         csv_lines = in_file.readlines()
         if in_file.name == '<stdin>':
             reset_stdin()
-        ledger_lines = process_csv_lines(csv_lines)
+        ledger_lines, unmatched_lines = process_csv_lines(csv_lines)
         print(*ledger_lines, sep='\n', file=out_file)
+        print(*unmatched_lines, sep='\n', file=err_file)
+
+        return unmatched_lines == []
 
     def process_csv_lines(csv_lines):
         dialect = None
@@ -707,6 +734,7 @@ def main():
         bank_reader = csv.reader(csv_lines[options.skip_lines:], dialect)
 
         ledger_lines = []
+        unmatched_lines = []
         for i, row in enumerate(bank_reader):
             # Skip any empty lines in the input
             if len(row) == 0:
@@ -714,15 +742,20 @@ def main():
 
             entry = Entry(row, csv_lines[options.skip_lines + i],
                           options)
-            payee, account, tags = get_payee_and_account(entry)
-            ledger_lines.append(
-                entry.journal_entry(i + 1, payee, account, tags))
+            try:
+                payee, account, tags = get_payee_and_account(entry)
+                ledger_lines.append(
+                    entry.journal_entry(i + 1, payee, account, tags))
+            except MatchingFailed, e:
+                unmatched_lines.append(e.line)
 
-        return ledger_lines
+        return ledger_lines, unmatched_lines
 
-    process_input_output(options.infile, options.outfile)
+    return process_input_output(options.infile, options.outfile, options.rejects_file)
 
 if __name__ == "__main__":
-    main()
+    if not main():
+        # we have failed to process some lines
+        sys.exit(2)
 
 # vim: ts=4 sw=4 et


### PR DESCRIPTION
Have had a thousands of lines long CSV (several years worth of transaction history) that I wanted to fold into ledger. Thanks to icsv2ledger it was actually doable, but it had to be an iterative process to find entries that could be easily matched, filter them out (and put them into ledger) and repeat until the only ones that remained were mostly in ledger already or could not be matched automatically anyway and deal with those.

This is what I ended up using: I added a new non-interactive mode that processed what it could and the rest was dumped to a separate file for the next iteration. It is not completely polished as it had sufficed, so the CSV header nor skipped lines are preserved, etc.