### PR TITLE
Add support for uuid transaction tag

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -405,12 +405,19 @@ class Entry:
         """
         template = (self.transaction_template
                     if self.transaction_template else DEFAULT_TEMPLATE)
+        uuid_regex = re.compile(r"UUID:", re.IGNORECASE)
+        uuid = [v for v in tags if uuid_regex.match(v)]
+        if uuid:
+          uuid = uuid[0]
+          tags.remove(uuid)
         format_data = {
             'date': self.date,
             'effective_date': self.effective_date,
             'cleared_character': self.cleared_character,
             'payee': payee,
             'transaction_index': transaction_index,
+
+            'uuid': uuid,
 
             'debit_account': account,
             'debit_currency': self.currency if self.debit else "",


### PR DESCRIPTION
The UUID tag must be a transaction tag in order to be usable with ledger, in case when the tags are written as posting tags in the template an additional handle (in this case `uuid`) is necessary in order to add it as a transaction tag.
For details see [An interesting feature by coincidence](https://groups.google.com/forum/#!searchin/ledger-cli/UUID/ledger-cli/ooxbPVRinSs/0OO92nw1rCMJ).

