### PR TITLE
Changes $0 entries to blank to avoid unbalanced transactions

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -372,6 +372,10 @@ class Entry:
 
         self.credit = get_field_at_index(fields, options.credit, options.csv_decimal_comma, options.ledger_decimal_comma)
         self.debit = get_field_at_index(fields, options.debit, options.csv_decimal_comma, options.ledger_decimal_comma)
+        if self.credit  and self.debit and float(self.credit) == 0:
+            self.credit = ''
+        elif self.debit and float(self.debit) == 0:
+            self.debit  = ''
 
         self.credit_account = options.account
         self.currency = options.currency


### PR DESCRIPTION
Fixes #74 

Only changes maximum of one credit/debit column of 0.00 to blank for the
unlikely case that both are $0.