### PR TITLE
Use "python2" instead of "python" in the shebang line

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Read CSV files and produce Ledger files out,
 # prompting for and learning accounts on the way.


### PR DESCRIPTION
icsv2ledger.py fails to run on systems where `/usr/bin/env python` points at a Python 3.x interpreter. The shebang line should explicitly use `/usr/bin/env python2`.