### PR TITLE
Add option to reverse the order of generated transactions

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -66,6 +66,7 @@ DEFAULTS = dotdict({
     'desc': str(2),
     'ledger_date_format': '',
     'quiet': False,
+    'reverse': False,
     'skip_lines': str(1),
     'tags': False,
     'delimiter': ',',
@@ -216,6 +217,11 @@ def parse_args_and_config_file():
         type=int,
         help=('number of lines to skip from CSV file'
               ' (default: {0})'.format(DEFAULTS.skip_lines)))
+    parser.add_argument(
+        '--reverse',
+        action='store_true',
+        help=('reverse the order of entries in the CSV file'
+              ' (default: {0})'.format(DEFAULTS.reverse)))
     parser.add_argument(
         '--cleared-character',
         choices='*! ',
@@ -730,6 +736,8 @@ def main():
             ledger_lines.append(
                 entry.journal_entry(i + 1, payee, account, tags))
 
+        if options.reverse:
+            ledger_lines.reverse()
         return ledger_lines
 
     process_input_output(options.infile, options.outfile)


### PR DESCRIPTION
The CSV files from some of my banks (e.g. BarclayCard) have the entries listed in reverse chronological order, whereas I want the ledger transactions to be in chronological order.

I ended up adding a simple `--reverse` option since that was all I needed. However, perhaps a `--sort` option that sorts by date would be more generally useful? Let me know and I can update this pull request.