### PR TITLE
Handle CSV files with non-UTF-8 encodings, or users with non-UTF-8 locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options can either be used from command line or in configuration file.
     --delimiter           CSV delimiter
     --desc STR            CSV column number matching description
     --effective-date INT  CSV column number matching effective date
+    --encoding STR        text encoding of CSV input file
     --ledger-date-format STR
                           date format for ledger output file
     --ledger-decimal-comma
@@ -210,6 +211,12 @@ is the CSV column number which contains the date to be used as the
 effective date. Default is `0`. Use of this option currently requires a
 template file. See section
 [Transaction template file](#transaction-template-file).
+
+**`--encoding STR`**
+
+is the text encoding of the CSV input file. Default is `utf-8`. The encoding
+should be specified if the CSV file contains non-ASCII characters (typically in
+the transaction description) in an encoding other than UTF-8.
 
 **`--ledger-date-format STR`**
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See also documentation of `--debit` option for negating amounts.
 describes the date format in the CSV file. 
 
 See the
-[python documentation](http://docs.python.org/library/datetime.html#strftime-strptime-behavior)
+[python documentation](http://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior)
 for the various format codes supported in this expression.
 
 **`--csv-decimal-comma`**
@@ -219,7 +219,7 @@ defined to be able to convert dates. If `--ledger-date-format` is not
 defined, then the date from CSV file is reused.
 
 See the
-[python documentation](http://docs.python.org/library/datetime.html#strftime-strptime-behavior)
+[python documentation](http://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior)
 for the various format codes supported in this expression.
 
 **`--ledger-decimal-comma`**
@@ -418,7 +418,7 @@ The built-in default template is as follows:
         {credit_account:<60}    {credit_currency} {credit}
 
 Details on how to format the template are found in the
-[Format Specification Mini-Language](http://docs.python.org/library/string.html#formatspec).
+[Format Specification Mini-Language](http://docs.python.org/3/library/string.html#formatspec).
 
 The values that can be used are: `date`, `effective_date`, `cleared_character`,
 `payee`, `transaction_index`, `debit_account`, `debit_currency`, `debit`,

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -7,6 +7,7 @@
 
 import argparse
 import csv
+import io
 import sys
 import os
 import hashlib
@@ -53,6 +54,7 @@ DEFAULTS = dotdict({
     'debit': str(3),
     'default_expense': 'Expenses:Unknown',
     'desc': str(2),
+    'encoding': 'utf-8',
     'ledger_date_format': '',
     'quiet': False,
     'reverse': False,
@@ -183,6 +185,11 @@ def parse_args_and_config_file():
         default=sys.stdout,
         help=('output filename or stdout in Ledger syntax'
               ' (default: {0})'.format('stdout')))
+    parser.add_argument(
+        '--encoding',
+        metavar='STR',
+        help=('encoding of csv file'
+              ' (default: {0})'.format(DEFAULTS.encoding)))
 
     parser.add_argument(
         '--ledger-file', '-l',
@@ -320,6 +327,10 @@ def parse_args_and_config_file():
               ' if ledger_date_format is defined.',
               file=sys.stderr)
         sys.exit(1)
+
+    if args.encoding != args.infile.encoding:
+        args.infile = io.TextIOWrapper(args.infile.detach(),
+                                       encoding=args.encoding)
 
     return args
 


### PR DESCRIPTION
I have some CSV files from PayPal that have non-ASCII payee names and are encoded in ISO-8859-1. These names get mangled with the current version of icsv2ledger running on my computer (with an en_US.UTF-8 locale).

I tried fixing this in python2 by converting strings to/from Unicode as needed, and it was turning into a very painful mess. Not the least because the cvs module in python2 doesn't support Unicode. Switching to python3 ended up being a much saner approach that required minimal changes to add proper Unicode handling. I hope upping icsv2ledger's python requirement is not a deal-breaker.

**NOTE**: I assume that all input and output files other than the CSV file (i.e. templates, mappings, ledgers, etc.) are in UTF-8. If the user has been using icsv2ledger in a non-UTF-8 locale
with non-ASCII CSV files then they will have to manually convert their template and mapping files (and possibly ledger files, if they haven't been keeping them in UTF-8 as they should) to UTF-8 encoding before updating to this version of icsv2ledger.