### PR TITLE
Support special characters, such as tab, as the CSV field delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ for ledger transactions. Default is `Expenses:Unknown`.
 
 **`--delimiter STR`**
 
-is the CSV delimiter character. Default is `,`.
+is the CSV delimiter character. Default is `,`. Special characters can be
+expressed using standard escape sequences, such as `\t` for a tab.
 
 **`--desc STR`**
 

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -121,6 +121,16 @@ class SortingHelpFormatter(HelpFormatter):
         super(SortingHelpFormatter, self).add_arguments(actions)
 
 
+def decode_escape_sequences(string):
+    # The `unicode_escape` decoder can only handle ASCII input, so it can't be
+    # fed a complete string with arbitrary characters. Instead, it is used only
+    # on the subsequences of the input string that have escape sequences and
+    # are guaranteed to only contain ASCII characters.
+    return re.sub(r'(?a)\\[\\\w{}]+',
+                  lambda m: m.group().encode('ascii').decode('unicode_escape'),
+                  string),
+
+
 def parse_args_and_config_file():
     """ Read options from config file and CLI args
     1. Reads hard coded DEFAULTS
@@ -312,8 +322,9 @@ def parse_args_and_config_file():
     parser.add_argument(
         '--delimiter',
         metavar='STR',
-        help=('delimiter between field in the csv'
-              ' (default: {0})'.format(DEFAULTS.csv_date_format)))
+        type=decode_escape_sequences,
+        help=('delimiter between fields in the csv'
+              ' (default: {0})'.format(DEFAULTS.delimiter)))
 
     args = parser.parse_args(remaining_argv)
 


### PR DESCRIPTION
This depends on pull request #81. Though if moving to python3 ends up not being an option, this pull request can also be trivially changed to support python2. This also fixes the incorrect help text for the `--delimiter` option.