### PR TITLE
Fix parsing of debit/credit columns that contain currency signs

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -450,10 +450,17 @@ def get_field_at_index(fields, index, csv_decimal_comma, ledger_decimal_comma):
     If the index is less than 0, then we invert the sign of
     the field at the given index
     """
+    if csv_decimal_comma:
+        decimal_separator = ','
+    else:
+        decimal_separator = '.'
+
+    re_non_number = '[^-0-9' + decimal_separator + ']'
+
     if index == 0:
         value = ""
     elif index < 0:
-        value = fields[-index - 1]
+        value = re.sub(re_non_number, '', fields[-index - 1])
         if value.startswith("-"):
             value = value[1:]
         elif value == "":
@@ -461,14 +468,7 @@ def get_field_at_index(fields, index, csv_decimal_comma, ledger_decimal_comma):
         else:
             value = "-" + value
     else:
-        value = fields[index - 1]
-
-    if csv_decimal_comma:
-        decimal_separator = ','
-    else:
-        decimal_separator = '.'
-    re_non_number = '[^-0-9' + decimal_separator + ']'
-    value = re.sub(re_non_number, '', value)
+        value = re.sub(re_non_number, '', fields[index - 1])
 
     if csv_decimal_comma and not ledger_decimal_comma:
         value = value.replace(',', '.')


### PR DESCRIPTION
When the `debit` or `credit` options are set to a negative number, the
negation logic fails if the CSV value contains non-numeric characters in
it. For example, a value of "$-42.55" is incorrectly transformed into
"--42.55" instead of "42.55". This is fixed by stripping non-numeric
characters from numeric CSV values before the negation happens rather
than after.