### PR TITLE
--src-account option added to allow sections of config file to be used as generic import recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ Options summary
 ---------------
 
 Options can either be used from command line or in configuration file.
-`--account` is a mandatory option on command line. `--config-file` and
+`--account` is a mandatory option on command line. `--config-file`, `--src-account` and
 `--help` are only usable from command line.
 
     --account STR, -a STR
                           ledger account used as source
+    --src-account STR
+                          ledger account used as source, overrides --account option
     --clear-screen, -C    clear screen for every transaction
     --cleared-character {*,!, }
                           character to clear a transaction
@@ -126,6 +128,10 @@ overridden in configuration file. See section
 [Configuration file example](#configuration-file-example) where `SAV`
 from command line is overridden with `account=Assets:Bank:Savings
 Account`.
+
+**`--src-account STR`**
+
+similar to --acount option, it is the ledger account used as source for ledger transactions but allows the --account option to be overriden after the config file has been parsed.  This is a command-line only option and must not be provided in any section of the config file.  Use of this option allows users to treat sections of the config file as generic import receipes that can be used to import all files that use the same layout while providing a means to specify the ledger source account to use during the importing of transactions.
 
 **`--clear-screen, -C`**
 
@@ -454,6 +460,7 @@ The built-in default template is as follows:
         ; CSV: {csv}
         {debit_account:<60}    {debit_currency} {debit}
         {credit_account:<60}    {credit_currency} {credit}
+        {tags}
 
 Details on how to format the template are found in the
 [Format Specification Mini-Language](http://docs.python.org/3/library/string.html#formatspec).

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Account`.
 
 **`--src-account STR`**
 
-similar to --acount option, it is the ledger account used as source for ledger transactions but allows the --account option to be overriden after the config file has been parsed.  This is a command-line only option and must not be provided in any section of the config file.  Use of this option allows users to treat sections of the config file as generic import receipes that can be used to import all files that use the same layout while providing a means to specify the ledger source account to use during the importing of transactions.
+similar to --acount option, it is the ledger account used as source for ledger transactions but allows the --account option to be overriden after the config file has been parsed.  This is a command-line only option and must not be provided in any section of the config file.  Use of this option allows users to treat sections of the config file as generic import recipes that can be used to import all files that use the same layout while providing a means to specify the ledger source account to use during the importing of transactions.
 
 **`--clear-screen, -C`**
 

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -211,7 +211,13 @@ def parse_args_and_config_file():
                   file=sys.stderr)
             sys.exit(1)
         defaults = dict(config.items(args.account))
-        print(defaults)
+        
+        if defaults['src_account']:
+            print('Section {0} in config file {1} contains command line only option src_account'
+                  .format(args.account, args.config_file),
+                  file=sys.stderr)
+            sys.exit(1)
+            
         defaults['addons'] = {}
         if config.has_section(args.account + '_addons'):
             for item in config.items(args.account + '_addons'):
@@ -490,7 +496,7 @@ class Entry:
         elif self.credit and self.debit and atof(self.debit) == 0:
             self.debit  = ''
 
-        self.credit_account = optons.account
+        self.credit_account = options.account
         if options.src_account:
             self.credit_account = options.src_account
         

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -86,6 +86,7 @@ DEFAULTS = dotdict({
     # For configparser, int must be converted to str
     # For configparser, boolean must be set to False
     'account': 'Assets:Bank:Current',
+    'src_account': '',
     'clear_screen': False,
     'cleared_character': '*',
     'credit': str(4),
@@ -210,6 +211,7 @@ def parse_args_and_config_file():
                   file=sys.stderr)
             sys.exit(1)
         defaults = dict(config.items(args.account))
+        print(defaults)
         defaults['addons'] = {}
         if config.has_section(args.account + '_addons'):
             for item in config.items(args.account + '_addons'):
@@ -261,6 +263,11 @@ def parse_args_and_config_file():
         action='store_true',
         help=('do not prompt if account can be deduced'
               ' (default: {0})'.format(DEFAULTS.quiet)))
+    parser.add_argument(
+        '--src-account',
+        metavar='STR',
+        help=('ledger source account to use, overrides --account option specified in config section'
+              ' (default: {0})'.format(DEFAULTS.src_account)))
     parser.add_argument(
         '--default-expense',
         metavar='STR',
@@ -483,7 +490,10 @@ class Entry:
         elif self.credit and self.debit and atof(self.debit) == 0:
             self.debit  = ''
 
-        self.credit_account = options.account
+        self.credit_account = optons.account
+        if options.src_account:
+            self.credit_account = options.src_account
+        
         self.currency = options.currency
         self.credit_currency = getattr(
             options, 'credit_currency', self.currency)


### PR DESCRIPTION
added command line only option --src-account that can be used to override --acount option value after config file has been read.  This effectively allows sections of config file to be used as generic import recipes that can be reused to import files that use the same layout while giving the option to specify the source ledger account to use during each import.