### PR TITLE
Correctly reference ArgumentTypeError

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -52,7 +52,7 @@ class FileType(object):
                         self._errors, newline=self._newline)
         except OSError as e:
             message = "can't open '%s': %s"
-            raise ArgumentTypeError(message % (string, e))
+            raise argparse.ArgumentTypeError(message % (string, e))
 
     def __repr__(self):
         args = self._mode, self._bufsize


### PR DESCRIPTION
ArgumentTypeError is undefined as it is never imported directly:
  > File "./icsv2ledger/icsv2ledger.py", line 55, in __call__
  >   raise ArgumentTypeError(message % (string, e))
  > NameError: name 'ArgumentTypeError' is not defined

This change references it correctly.