### PR TITLE
Remove unused imports

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -15,11 +15,9 @@ import hashlib
 import re
 import subprocess
 import readline
-import rlcompleter
 import configparser
 from argparse import HelpFormatter
 from datetime import datetime
-from datetime import date
 from operator import attrgetter
 from locale   import atof
 


### PR DESCRIPTION
The imported modules 'rlcompleter' and 'date' are not being used. With
this change we remove these imports.