### PR TITLE
Handle KeyboardInterrupt from dupe detection gracefully

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -949,12 +949,7 @@ def main():
                     if value.upper().strip() not in ('N','NO'):
                         continue
                 while True:
-                    try:
-                        payee, account, tags = get_payee_and_account(entry)
-                    except KeyboardInterrupt:
-                        print()
-                        sys.exit(0)
-                    
+                    payee, account, tags = get_payee_and_account(entry)
                     value = 'C'
                     if options.entry_review:
                         # need to display ledger formatted entry here
@@ -979,7 +974,11 @@ def main():
 
                 yield entry.journal_entry(i + 1, payee, account, tags)
 
-    process_input_output(options.infile, options.outfile)
+    try:
+        process_input_output(options.infile, options.outfile)
+    except KeyboardInterrupt:
+        print()
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
A KeyboardInterrupt exception, when raised during dupe detection, is not
handled gracefully as it should be:
  > Duplicate transaction detected, skip? [Y] > Traceback (most recent call last):
  >   File "icsv2ledger/icsv2ledger.py", line 946, in process_csv_lines
  >     yn_response = prompt_for_value('Duplicate transaction detected, skip?', possible_yesno, 'Y')
  >   File "icsv2ledger/icsv2ledger.py", line 778, in prompt_for_value
  >     return input('{0} [{1}] > '.format(prompt, default))
  >   KeyboardInterrupt

With this change we move the try-except handler for said exception into
the main function and thereby resolve this problem.