### PR TITLE
Strip spaces from date string before parsing

### DIFF
--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -487,7 +487,7 @@ class Entry:
             self.addons = dict()
 
         # Get the date and convert it into a ledger formatted date.
-        self.date = fields[options.date - 1]
+        self.date = fields[options.date - 1].strip()
         entry_date = datetime.strptime(self.date, options.csv_date_format)
         if options.ledger_date_format:
             if options.ledger_date_format != options.csv_date_format:


### PR DESCRIPTION
**Problem**
Some csv files can have an extra space after or before the date. For example:
```
10 Dec 2018 ; To John Doe  ; 20.75 ;  ;  ;  ; 48.35; transfers; groceries
```
Setting the `csv_date_format` to `%d %b %Y` won't work because the date has this extra space in the end: "10 Dec 2018 ".

**Solution**
We use `.strip()` on the date string before parsing it.