### PR TITLE
Add "pip install" support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .icsv2ledgerrc*
+tests/__pycache__
 tests/.pytest_cache
+venv/

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -1052,8 +1052,12 @@ def main(options):
         sys.exit(0)
 
 
-if __name__ == "__main__":
+def cli():
     options = parse_args_and_config_file()
     main(options)
+
+
+if __name__ == "__main__":
+    cli()
 
 # vim: ts=4 sw=4 et

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name='icsv2ledger',
+    description='Interactive importing of CSV files to Ledger',
+    url='https://github.com/quentinsf/icsv2ledger',
+    py_modules=['icsv2ledger'],
+    entry_points={
+        'console_scripts': ['icsv2ledger=icsv2ledger:cli']
+    }
+)


### PR DESCRIPTION
This adds support to install `icsv2ledger` with `pip`:
```
$ pip install https://github.com/quentinsf/icsv2ledger/archive/master.zip
```
`pip` makes `icsv2ledger` available system wide:
```
$ icsv2ledger [options] -a STR [infile [outfile]]
```
I hope, this is a useful addition to `icsv2ledger`. Looking forward to your feedback.