### PR TITLE
Add support for YAML configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,16 @@ are `*` or `!` or ` `. Default is `*`.
 
 is configuration filename.
 
-The file used will be first found in that order:
+Filenames ending in `.yaml` or `.yml` will be parsed with PyYAML,
+otherwise with configparser (INI style, see examples).
+
+The file used will be the first one found in the following order.
+Note that Steps 2 & 3 also check for `.yaml` & `.yml` varients, in
+that order (ie. `.icsv2ledgerrc.yml`).
 
 1. Filename given on command line with `--config-file`,
-2. `.icsv2ledgerrc` in current directory,
-3. `.icsv2ledgerrc` in home directory.
+2. `.icsv2ledgerrc` (+YAML varients) in current directory,
+3. `.icsv2ledgerrc` (+YAML varients) in home directory.
 
 **`--credit INT`**
 
@@ -404,6 +409,47 @@ CHQ.
     debit=4
     mapping_file=mappings.CHQ
     skip_lines=0
+
+YAML configuration example
+--------------------------
+
+Configuration files ending in `.yaml` or `.yml` will be parsed with
+PyYAML if availible, allowing for the use of anchors, filters, and
+other YAML-spec features.
+
+Note that options are an unordered list, and that the `desc` field
+must be quoted to explicitly denote a string.
+
+    ---
+
+    SAV: &sav_anchor
+      account:  Assets:Bank:Savings Account
+      currency: AUD
+      date:     1
+      csv_date_format:    %d-%b-%y
+      ledger_date_format: %Y/%m/%d
+      desc:  '6'
+      credit: 2
+      debit: -1
+      mapping_file: mappings.SAV
+
+    SAV_addons:
+      beneficiary: 3
+      purpose:     4
+
+
+    CHQ:
+      # This use of an anchor designates `CHQ` as an extension of `SAV`,
+      # inheriting it's values (currency, date, ledger_date_format, etc.)
+      # as defaults.
+      <<: *sav_anchor
+      account: Assets:Bank:Cheque Account
+      csv_date_format: %d/%m/%Y
+      desc:  '2'
+      credit: 3
+      debit:  4
+      mapping_file: mappings.CHQ
+      skip_lines: 0
 
 
 Addons

--- a/icsv2ledger.py
+++ b/icsv2ledger.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from operator import attrgetter
 from locale   import atof
 from typing import AnyStr, Pattern, Optional
+from itertools import chain
 
 
 class FileType(object):
@@ -116,9 +117,12 @@ DEFAULTS = dotdict({
     'entry_review': False})
 
 FILE_DEFAULTS = dotdict({
-    'config_file': [
-        os.path.join('.', '.icsv2ledgerrc'),
-        os.path.join(os.path.expanduser('~'), '.icsv2ledgerrc')],
+    # Re-phrased into Bash for clarity, this list comprehension
+    # generates: {'./',"$HOME/"}.icsv2ledgerrc{'','.yaml','.yml'}
+    'config_file': (list(chain.from_iterable([
+        [os.path.join(root, '.icsv2ledgerrc') + suffix
+            for suffix in ['', '.yaml', '.yml']]
+                for root in ['.', os.path.expanduser('~')]]))),
     'ledger_file': [
         os.path.join('.', '.ledger'),
         os.path.join(os.path.expanduser('~'), '.ledger')],
@@ -210,7 +214,29 @@ def parse_args_and_config_file():
     if args.config_file and ('-h' not in remaining_argv and
                              '--help' not in remaining_argv):
         config = configparser.RawConfigParser(DEFAULTS)
-        config.read(args.config_file)
+
+        # For YAML files
+        if args.config_file.endswith(('.yaml', '.yml')):
+            with open(args.config_file, 'r') as stream:
+                try:
+                    from yaml import safe_load, YAMLError
+                    result=safe_load(stream)
+                    config.read_dict(result)
+                except (ImportError, ModuleNotFoundError) as exc:
+                    print(exc)
+                    print("\nYAML config provided, but PyYAML could not be imported.\n"
+                          "Please ensure it has been installed (eg. via pip):\n"
+                          "    pip install PyYAML")
+                    sys.exit(1)
+                except YAMLError as exc:
+                    print("\nYAML configuration error:\n")
+                    print(exc)
+                    sys.exit(1)
+
+        # For configparser files
+        else:
+            config.read(args.config_file)
+
         if not config.has_section(args.account):
             print('Config file {0} does not contain section {1}'
                   .format(args.config_file, args.account),


### PR DESCRIPTION
Applies to any provided config file ending in `.yaml` or `.yml`, and searches for `./.icsv2ledgerrc.yaml` and `./.icsv2ledgerrc.yml` by default.

Includes updates to documentation with an explanation of file path precedence and an adaptation of the existing configuration example.

Although PyYAML parses the configuration file into a dict, we immediately read it into configparser to maintain consistency in the rest of the program.

Adds an import of `chain` from the `itertools` module to succinctly flatten a list of list comprehensions in the config file search-path section. I've done further refactoring of this section on my personal fork, but that's to my preferences, and likely not Pythonic, as I'm still learning what that means- my instincts are probably too DRY :p
Hence, I've kept this patch minimal, and only changed the lines that I needed to.

I'd have liked to support passing a list of field-indexes to the `desc` option, instead of the current solution of quoting it into a string for the existing regex-split, but found that it was always parsed in as a string (`'[2, 5]'`) instead of a list (`[2, 5]`), so it kept trying to iterate over the square brackets? I'm really new to Python, and am clearly missing something here. Comments welcome!